### PR TITLE
avg_cpu_utilization_high corrected to 50

### DIFF
--- a/steampipe.spvars
+++ b/steampipe.spvars
@@ -17,4 +17,4 @@ logging_bucket_max_retention_days = 30
 # SQL
 sql_db_instance_avg_connections          = 2
 sql_db_instance_avg_cpu_utilization_low  = 25
-sql_db_instance_avg_cpu_utilization_high = 25
+sql_db_instance_avg_cpu_utilization_high = 50


### PR DESCRIPTION
### Checklist
- [x] https://github.com/turbot/steampipe-mod-gcp-thrifty/issues/17